### PR TITLE
[WIP][TASK] Implement interfaces, base and refrence implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+---
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  php-lint:
+    name: "PHP Lint"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.1"
+          - "8.2"
+          - "8.3"
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Display branch name
+        run: |
+          echo "Current branch: ${{ steps.extract_branch.outputs.branch }}"
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Lint php"
+        run: |
+          find . -name \\*.php ! -path "./vendor/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
+
+  unit-tests:
+    name: "Unit Tests"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.1"
+          - "8.2"
+          - "8.3"
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Display branch name
+        run: |
+          echo "Current branch: ${{ steps.extract_branch.outputs.branch }}"
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+      - name: "Install all dependencies"
+        run: |
+          composer install
+      - name: "Execute unit tests"
+        run: |
+          vendor/bin/phpunit tests/Unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+/vendor/
+/composer.lock
+/.phpunit.cache
+/.php-cs-fixer.cache
+/.php-cs-fixer.php

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+$headerComment = <<<COMMENT
+This file is part of the CMS Health Project.
+
+It is free software; you can redistribute it and/or modify it under
+the terms of the MIT License.
+
+For the full copyright and license information, please read the
+LICENSE file that was distributed with this source code.
+COMMENT;
+
+// Return a Code Sniffing configuration using
+// all sniffers needed for PER
+// and additionally:
+//  - Remove leading slashes in use clauses.
+//  - PHP single-line arrays should not have trailing comma.
+//  - Single-line whitespace before closing semicolon are prohibited.
+//  - Remove unused use statements in the PHP source code
+//  - Ensure Concatenation to have at least one whitespace around
+//  - Remove trailing whitespace at the end of blank lines.
+return (new \PhpCsFixer\Config())
+    ->setFinder(
+        (new PhpCsFixer\Finder())
+            ->ignoreVCSIgnored(true)
+            ->in(realpath(__DIR__ . '/'))
+    )
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1.0' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => ['space' => 'none'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'type_declaration_spaces' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'method_argument_space' => true,
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_useless_nullsafe_operator' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'single_line_empty_body' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+        'header_comment' => [
+            'header' => $headerComment,
+            'comment_type' => 'comment',
+            'separate' => 'both',
+            'location' => 'after_declare_strict',
+        ],
+    ]);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "cfhack/cms-health-hackathon",
+  "description": "CMS Health Check Data",
+  "type": "library",
+  "license": "MIT License",
+  "autoload": {
+    "psr-4": {
+      "Cfhack\\CmsHealth\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Cfhack\\CmsHealth\\Tests\\": "tests/"
+    }
+  },
+  "require": {
+    "php": "^8.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.5",
+    "friendsofphp/php-cs-fixer": "^3.51"
+  },
+  "scripts": {
+    "cgl:check": "@php vendor/bin/php-cs-fixer check --verbose --show-progress=dots --diff",
+    "cgl:fix": "@php vendor/bin/php-cs-fixer fix --verbose --show-progress=dots",
+    "tests:unit": "@php vendor/bin/phpunit"
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+    Unit test suite setup
+
+    Unit tests should extend \TYPO3\TestingFramework\Core\Tests\UnitTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS unit test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as UnitTestsBootstrap.php
+
+    The recommended way to execute the suite is "runTests.sh -s unit"
+    execute "Build/Scripts/runTests.sh -h" for more details.
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+    backupGlobals="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    cacheDirectory=".phpunit.cache"
+    cacheResult="false"
+    colors="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnDeprecation="true"
+    failOnNotice="true"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
+</phpunit>

--- a/src/CheckInterface.php
+++ b/src/CheckInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth;
+
+interface CheckInterface
+{
+    public function getIdentifier(): string;
+    public function getComponentId(): string;
+    public function getComponentType(): string;
+    public function getStatus(): string;
+    public function getObservedValue(): string;
+    public function getObservedUnit(): string;
+    public function getOutput(): string;
+    public function getTime(): string;
+}

--- a/src/GlobalCheckInterface.php
+++ b/src/GlobalCheckInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth;
+
+interface GlobalCheckInterface
+{
+    public function getStatus(): string;
+    public function getVersion(): string;
+    public function getServiceId(): string;
+    public function getDescription(): string;
+
+    /**
+     * @return array<string, CheckInterface>
+     */
+    public function getChecks(): array;
+}

--- a/src/Reference/Check.php
+++ b/src/Reference/Check.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference;
+
+use Cfhack\CmsHealth\CheckInterface;
+
+class Check implements CheckInterface
+{
+    public function __construct(
+        public string $identifier,
+        public string $componentId,
+        public ComponentType $componentType,
+        public Status $status,
+        public string $observedValue,
+        public string $observedUnit,
+        public string $output,
+        public \DateTime $time,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getComponentId(): string
+    {
+        return $this->componentId;
+    }
+
+    public function getComponentType(): string
+    {
+        return $this->componentType->value;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status->value;
+    }
+
+    public function getObservedValue(): string
+    {
+        return $this->observedValue;
+    }
+
+    public function getObservedUnit(): string
+    {
+        return $this->observedUnit;
+    }
+
+    public function getOutput(): string
+    {
+        return $this->output;
+    }
+
+    public function getTime(): string
+    {
+        // $format = 'Y-m-d\TH:i:s.uP';
+        $format = 'Y-m-d\TH:i:sP';
+        return $this->time->format($format);
+    }
+}

--- a/src/Reference/CheckCollection.php
+++ b/src/Reference/CheckCollection.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference;
+
+use Cfhack\CmsHealth\CheckInterface;
+
+class CheckCollection implements CheckCollectionInterface
+{
+    /**
+     * @var array<string, CheckInterface>
+     */
+    private array $checks = [];
+
+    public function add(CheckInterface ...$checks): void
+    {
+        foreach ($checks as $check) {
+            $this->checks[$check->identifier] = $check;
+        }
+    }
+
+    public function delete(CheckInterface|string ...$checks): void
+    {
+        foreach ($checks as $check) {
+            $identifier = is_string($check)
+                ? $check
+                : $check->identifier;
+            unset($this->checks[$identifier]);
+        }
+    }
+
+    public function has(string $identifier): bool
+    {
+        return ($this->checks[$identifier] ?? null) !== null;
+    }
+
+    public function get(string $identifier): CheckInterface|null
+    {
+        return $this->has($identifier)
+            ? $this->checks[$identifier]
+            : null;
+    }
+
+    /**
+     * @return array<string, CheckInterface>
+     */
+    public function items(): array
+    {
+        return $this->checks;
+    }
+}

--- a/src/Reference/CheckCollectionInterface.php
+++ b/src/Reference/CheckCollectionInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference;
+
+use Cfhack\CmsHealth\CheckInterface;
+
+interface CheckCollectionInterface
+{
+    /**
+     * @return array<non-empty-string, CheckInterface>
+     */
+    public function items(): array;
+}

--- a/src/Reference/ComponentType.php
+++ b/src/Reference/ComponentType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference;
+
+enum ComponentType: string
+{
+    case System = 'system';
+    case Component = 'component';
+    case DataStorage = 'datastorage';
+}

--- a/src/Reference/GlobalCheck.php
+++ b/src/Reference/GlobalCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference;
+
+use Cfhack\CmsHealth\GlobalCheckInterface;
+
+class GlobalCheck implements GlobalCheckInterface
+{
+    public function __construct(
+        public Status $status,
+        public string $version,
+        public string $serviceId,
+        public string $description,
+        public CheckCollectionInterface $checks,
+    ) {}
+
+    public function getStatus(): string
+    {
+        return $this->status->value;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getServiceId(): string
+    {
+        return $this->serviceId;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return array<string, Check>
+     */
+    public function getChecks(): array
+    {
+        return $this->checks->items();
+    }
+}

--- a/src/Reference/Serializable/SerializableCheck.php
+++ b/src/Reference/Serializable/SerializableCheck.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference\Serializable;
+
+use Cfhack\CmsHealth\Reference\Check;
+
+class SerializableCheck extends Check implements SerializableCheckInterface
+{
+    /**
+     * @return array{
+     *   componentId: string,
+     *   componentType: string,
+     *   status: string,
+     *   observedValue: string,
+     *   observedUnit: string,
+     *   output: string,
+     *   time: string,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'componentId' => $this->getComponentId(),
+            'componentType' => $this->getComponentType(),
+            'status' => $this->getStatus(),
+            'observedValue' => $this->getObservedValue(),
+            'observedUnit' => $this->getObservedUnit(),
+            'output' => $this->getOutput(),
+            'time' => $this->getTime(),
+        ];
+    }
+}

--- a/src/Reference/Serializable/SerializableCheckCollection.php
+++ b/src/Reference/Serializable/SerializableCheckCollection.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference\Serializable;
+
+class SerializableCheckCollection implements SerializableCheckCollectionInterface
+{
+    /**
+     * @var array<string, SerializableCheckInterface>
+     */
+    private array $checks = [];
+
+    public function add(SerializableCheckInterface ...$checks): void
+    {
+        foreach ($checks as $check) {
+            $this->checks[$check->getIdentifier()] = $check;
+        }
+    }
+
+    public function delete(SerializableCheckInterface|string ...$checks): void
+    {
+        foreach ($checks as $check) {
+            $identifier = is_string($check)
+                ? $check
+                : $check->getIdentifier();
+            unset($this->checks[$identifier]);
+        }
+    }
+
+    public function has(string $identifier): bool
+    {
+        return ($this->checks[$identifier] ?? null) !== null;
+    }
+
+    public function get(string $identifier): SerializableCheckInterface|null
+    {
+        return $this->has($identifier)
+            ? $this->checks[$identifier]
+            : null;
+    }
+
+    /**
+     * @return array<string, SerializableCheckInterface>
+     */
+    public function items(): array
+    {
+        return $this->checks;
+    }
+
+    /**
+     * @return array<string, SerializableCheckInterface>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->items();
+    }
+}

--- a/src/Reference/Serializable/SerializableCheckCollectionInterface.php
+++ b/src/Reference/Serializable/SerializableCheckCollectionInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference\Serializable;
+
+use Cfhack\CmsHealth\Reference\CheckCollectionInterface;
+
+interface SerializableCheckCollectionInterface extends CheckCollectionInterface, \JsonSerializable
+{
+    /**
+     * @return array<non-empty-string, SerializableCheck>
+     */
+    public function items(): array;
+
+    /**
+     * @return array<non-empty-string, SerializableCheck>
+     */
+    public function jsonSerialize(): array;
+}

--- a/src/Reference/Serializable/SerializableCheckInterface.php
+++ b/src/Reference/Serializable/SerializableCheckInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference\Serializable;
+
+use Cfhack\CmsHealth\CheckInterface;
+
+interface SerializableCheckInterface extends CheckInterface, \JsonSerializable
+{
+    /**
+     * @return array{
+     *   componentId: string,
+     *   componentType: string,
+     *   status: string,
+     *   observedValue: string,
+     *   observedUnit: string,
+     *   output: string,
+     *   time: string,
+     * }
+     */
+    public function jsonSerialize(): array;
+}

--- a/src/Reference/Serializable/SerializableGlobalCheck.php
+++ b/src/Reference/Serializable/SerializableGlobalCheck.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference\Serializable;
+
+use Cfhack\CmsHealth\Reference\GlobalCheck;
+use Cfhack\CmsHealth\Reference\Status;
+
+class SerializableGlobalCheck extends GlobalCheck implements \JsonSerializable
+{
+    public function __construct(
+        Status $status,
+        string $version,
+        string $serviceId,
+        string $description,
+        SerializableCheckCollectionInterface $checks,
+    ) {
+        parent::__construct($status, $version, $serviceId, $description, $checks);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'status' => $this->getStatus(),
+            'version' => $this->getVersion(),
+            'serviceId' => $this->getServiceId(),
+            'description' => $this->getDescription(),
+            'checks' => $this->getChecks(),
+        ];
+    }
+}

--- a/src/Reference/Status.php
+++ b/src/Reference/Status.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Reference;
+
+enum Status: string
+{
+    case Pass = 'pass';
+    case Ok = 'ok';
+    case Fail = 'fail';
+    case Error = 'error';
+    case Warn = 'warn';
+
+    public function passes(): bool
+    {
+        return $this === self::Pass || $this === self::Ok;
+    }
+
+    public function failes(): bool
+    {
+        return $this === self::Fail || $this === self::Error;
+    }
+
+    public function warns(): bool
+    {
+        return $this === self::Warn;
+    }
+}

--- a/tests/Unit/Reference/CheckTest.php
+++ b/tests/Unit/Reference/CheckTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Tests\Unit\Reference;
+
+use Cfhack\CmsHealth\CheckInterface;
+use Cfhack\CmsHealth\Reference\Check;
+use Cfhack\CmsHealth\Reference\ComponentType;
+use Cfhack\CmsHealth\Reference\Status;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CheckTest extends TestCase
+{
+    #[Test]
+    public function checkImplementsInterface(): void
+    {
+        $subject = $this->createSubject();
+        self::assertInstanceOf(CheckInterface::class, $subject);
+    }
+
+    #[Test]
+    public function propertyIdentifierReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('tester:check', $subject->identifier);
+    }
+
+    #[Test]
+    public function getIdentifierReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('tester:check', $subject->getIdentifier());
+    }
+
+    #[Test]
+    public function propertyComponentIdReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('component-id', $subject->componentId);
+    }
+
+    #[Test]
+    public function getComponentIdReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('component-id', $subject->getComponentId());
+    }
+
+    #[Test]
+    public function propertyComponentTypeReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(ComponentType::System, $subject->componentType);
+    }
+
+    #[Test]
+    public function getComponentTypeReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(ComponentType::System->value, $subject->getComponentType());
+    }
+
+    #[Test]
+    public function propertyStatusReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(Status::Pass, $subject->status);
+    }
+
+    #[Test]
+    public function getStatusReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(Status::Pass->value, $subject->getStatus());
+    }
+
+    #[Test]
+    public function propertyObservedValueReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('1', $subject->observedValue);
+    }
+
+    #[Test]
+    public function getObservedValueReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('1', $subject->getObservedValue());
+    }
+
+    #[Test]
+    public function propertyObservedUnitReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('unit', $subject->observedUnit);
+    }
+
+    #[Test]
+    public function getObservedUnitReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('unit', $subject->getObservedUnit());
+    }
+
+    #[Test]
+    public function propertyOutputReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('some-output', $subject->output);
+    }
+
+    #[Test]
+    public function getOutputReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('some-output', $subject->getOutput());
+    }
+
+    #[Test]
+    public function propertyTimeReturnsConstructorValue(): void
+    {
+        $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-16T12:34:56+00:00');
+        $subject = $this->createSubject();
+        self::assertSame($dateTime->getTimestamp(), $subject->time->getTimestamp());
+    }
+
+    #[Test]
+    public function getTimeReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('2024-03-16T12:34:56+00:00', $subject->getTime());
+    }
+
+    private function createSubject(
+        string $identifier = 'tester:check',
+        string $componentId = 'component-id',
+        ComponentType $componentType = ComponentType::System,
+        Status $status = Status::Pass,
+        string $observedValue = '1',
+        string $observedUnit = 'unit',
+        string $output = 'some-output',
+        \DateTime $time = null,
+    ): Check {
+        $time ??= \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-16T12:34:56+00:00');
+        return new Check(
+            $identifier,
+            $componentId,
+            $componentType,
+            $status,
+            $observedValue,
+            $observedUnit,
+            $output,
+            $time,
+        );
+    }
+}

--- a/tests/Unit/Reference/Serializable/Fixtures/SerializedCheckJsonEncodeTest.json
+++ b/tests/Unit/Reference/Serializable/Fixtures/SerializedCheckJsonEncodeTest.json
@@ -1,0 +1,9 @@
+{
+    "componentId": "component-id",
+    "componentType": "system",
+    "status": "pass",
+    "observedValue": "1",
+    "observedUnit": "unit",
+    "output": "some-output",
+    "time": "2024-03-16T12:34:56+00:00"
+}

--- a/tests/Unit/Reference/Serializable/SerializableCheckTest.php
+++ b/tests/Unit/Reference/Serializable/SerializableCheckTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the CMS Health Project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the MIT License.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Cfhack\CmsHealth\Tests\Unit\Reference\Serializable;
+
+use Cfhack\CmsHealth\Reference\ComponentType;
+use Cfhack\CmsHealth\Reference\Serializable\SerializableCheck;
+use Cfhack\CmsHealth\Reference\Serializable\SerializableCheckInterface;
+use Cfhack\CmsHealth\Reference\Status;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SerializableCheckTest extends TestCase
+{
+    #[Test]
+    public function checkImplementsInterface(): void
+    {
+        $subject = $this->createSubject();
+        self::assertInstanceOf(SerializableCheckInterface::class, $subject);
+    }
+
+    #[Test]
+    public function propertyIdentifierReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('tester:check', $subject->identifier);
+    }
+
+    #[Test]
+    public function getIdentifierReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('tester:check', $subject->getIdentifier());
+    }
+
+    #[Test]
+    public function propertyComponentIdReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('component-id', $subject->componentId);
+    }
+
+    #[Test]
+    public function getComponentIdReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('component-id', $subject->getComponentId());
+    }
+
+    #[Test]
+    public function propertyComponentTypeReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(ComponentType::System, $subject->componentType);
+    }
+
+    #[Test]
+    public function getComponentTypeReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(ComponentType::System->value, $subject->getComponentType());
+    }
+
+    #[Test]
+    public function propertyStatusReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(Status::Pass, $subject->status);
+    }
+
+    #[Test]
+    public function getStatusReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame(Status::Pass->value, $subject->getStatus());
+    }
+
+    #[Test]
+    public function propertyObservedValueReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('1', $subject->observedValue);
+    }
+
+    #[Test]
+    public function getObservedValueReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('1', $subject->getObservedValue());
+    }
+
+    #[Test]
+    public function propertyObservedUnitReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('unit', $subject->observedUnit);
+    }
+
+    #[Test]
+    public function getObservedUnitReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('unit', $subject->getObservedUnit());
+    }
+
+    #[Test]
+    public function propertyOutputReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('some-output', $subject->output);
+    }
+
+    #[Test]
+    public function getOutputReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('some-output', $subject->getOutput());
+    }
+
+    #[Test]
+    public function propertyTimeReturnsConstructorValue(): void
+    {
+        $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-16T12:34:56+00:00');
+        $subject = $this->createSubject();
+        self::assertSame($dateTime->getTimestamp(), $subject->time->getTimestamp());
+    }
+
+    #[Test]
+    public function getTimeReturnsConstructorValue(): void
+    {
+        $subject = $this->createSubject();
+        self::assertSame('2024-03-16T12:34:56+00:00', $subject->getTime());
+    }
+
+    #[Test]
+    public function jsonEncodeProducesExpectedResultOfObject(): void
+    {
+        $expected = file_get_contents(__DIR__ . '/Fixtures/SerializedCheckJsonEncodeTest.json');
+        $encoded = \json_encode(
+            $this->createSubject(),
+            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT
+        );
+
+        self::assertSame($expected, $encoded);
+    }
+
+    private function createSubject(
+        string $identifier = 'tester:check',
+        string $componentId = 'component-id',
+        ComponentType $componentType = ComponentType::System,
+        Status $status = Status::Pass,
+        string $observedValue = '1',
+        string $observedUnit = 'unit',
+        string $output = 'some-output',
+        \DateTime $time = null,
+    ): SerializableCheck {
+        $time ??= \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2024-03-16T12:34:56+00:00');
+        return new SerializableCheck(
+            $identifier,
+            $componentId,
+            $componentType,
+            $status,
+            $observedValue,
+            $observedUnit,
+            $output,
+            $time,
+        );
+    }
+}


### PR DESCRIPTION
This change adds the interfaces for the CMS Health Check objects
along with a simple base implementation.

The PSR like implementation boils down to only two interfaces:

* `GlobalCheckInterface` as the outer main object handling
* `CheckInterface` is the interface for a single check

On top, a enhanced serializable reference implementation is added
for showcasing purpose during the great CloudFest Hackathon 2024.
The reference implementation may be extracted later into it's own
reference implementation package but kept for now to pave the path
for a quick POC implementation during the Hackathon.

Basic `PHPUnit` based unit testing is added along the way together
with a simple `php-cs-fixer` based cgl setup. Usually, that should
be provided in dedicated changes.
